### PR TITLE
fix: gitlab sections and allow dot in usernames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /codeowners
+/.idea
+/co

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	go build ./cmd/codeowners
+	go build -o co ./cmd/codeowners

--- a/parse.go
+++ b/parse.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	emailRegexp    = regexp.MustCompile(`\A[A-Z0-9a-z\._%\+\-]+@[A-Za-z0-9\.\-]+\.[A-Za-z]{2,6}\z`)
-	teamRegexp     = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+\/[a-zA-Z0-9_\-]+)\z`)
-	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+)\z`)
+	emailRegexp    = regexp.MustCompile(`\A[A-Z0-9a-z._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,6}\z`)
+	teamRegexp     = regexp.MustCompile(`\A@([a-zA-Z0-9\-.]+/[a-zA-Z0-9_\-]+)\z`)
+	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-.]+)\z`)
 )
 
 const (
@@ -29,8 +29,8 @@ func ParseFile(f io.Reader) (Ruleset, error) {
 		lineNo++
 		line := scanner.Text()
 
-		// Ignore blank lines and comments
-		if len(line) == 0 || line[0] == '#' {
+		// Ignore blank lines and comments and gitlab sections
+		if len(line) == 0 || line[0] == '#' || line[0] == '[' {
 			continue
 		}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -23,6 +23,14 @@ func TestParseRule(t *testing.T) {
 			},
 		},
 		{
+			name: "username owners with . in the name",
+			rule: "file.txt @user.foo",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "file.txt"),
+				Owners:  []Owner{{Value: "user.foo", Type: "username"}},
+			},
+		},
+		{
 			name: "team owners",
 			rule: "file.txt @org/team",
 			expected: Rule{


### PR DESCRIPTION
### Description
This PR fixes minor issues encountered in codeowners files in gitlab
- ignores gitlab sections (e.g. [section group])
- allows dots for usernames